### PR TITLE
fix config generating process

### DIFF
--- a/tools/generate-config.sh
+++ b/tools/generate-config.sh
@@ -1,7 +1,5 @@
 #! /bin/sh
 
-. tools/common.sh
-
 find_command_from_path() {
   path=$(command -v "$1")
   [ -z "$path" ] && exit

--- a/zen-release
+++ b/zen-release
@@ -110,13 +110,14 @@ generate_config() {
   config_dir="$XDG_CONFIG_HOME"
   [ -z "$config_dir" ] && config_dir="$HOME"
   config_dir="$config_dir/.config/zen-desktop"
-  file_name="config.toml"
+  mkdir -p "$config_dir"
 
+  file_name="config.toml"
   while true; do
     [ ! -e "$config_dir/$file_name" ] && break
     file_name="$file_name.bak"
   done
-  mv "$config_dir/config.toml" "$config_dir/$file_name"
+  [ -e "$config_dir/$file_name" ] && mv "$config_dir/config.toml" "$config_dir/$file_name"
 
   echo "Generated $config_dir/config.toml"
   echo

--- a/zen-release
+++ b/zen-release
@@ -117,7 +117,7 @@ generate_config() {
     [ ! -e "$config_dir/$file_name" ] && break
     file_name="$file_name.bak"
   done
-  [ -e "$config_dir/$file_name" ] && mv "$config_dir/config.toml" "$config_dir/$file_name"
+  [ -e "$config_dir/config.toml" ] && mv "$config_dir/config.toml" "$config_dir/$file_name"
 
   echo "Generated $config_dir/config.toml"
   echo


### PR DESCRIPTION
- create config directory before dumping config
- prevent `mv` when `config.toml` doesn't exist